### PR TITLE
updated rw-lock construction and introduced exceptions to make construction more robust

### DIFF
--- a/lib/io/rw-lock/win32/ecal_named_rw_lock_impl.h
+++ b/lib/io/rw-lock/win32/ecal_named_rw_lock_impl.h
@@ -26,6 +26,45 @@
 #include "io/rw-lock/ecal_named_rw_lock_base.h"
 #include <atomic>
 
+class CreateMutexException : public std::exception {
+public:
+  CreateMutexException() : errorMessage("Could not create NamedMutex!") {};
+  CreateMutexException(const char* msg) : errorMessage(msg) {};
+
+  const char* what() const override{
+    return errorMessage.c_str();
+  }
+
+private:
+  std::string errorMessage;
+};
+
+class CreateEventException : public std::exception {
+public:
+  CreateEventException() : errorMessage("Could not create NamedEvent!") {};
+  CreateEventException(const char* msg) : errorMessage(msg) {};
+
+  const char* what() const override {
+    return errorMessage.c_str();
+  }
+
+private:
+  std::string errorMessage;
+};
+
+class SHMException : public std::exception {
+public:
+  SHMException() : errorMessage("Could not create shared memory!") {};
+  SHMException(const char* msg) : errorMessage(msg) {};
+
+  const char* what() const override {
+    return errorMessage.c_str();
+  }
+
+private:
+  std::string errorMessage;
+};
+
 struct named_rw_lock_state 
 {
   bool writer_active = false;


### PR DESCRIPTION
fixes #6 
During the construction of the rw-lock, GetLastError() is utilized to check if another process has already constructed the lock to prevent reseting the state while the lock is already in use.
