### PR TITLE
rw-lock releases locks at destruction

### DIFF
--- a/lib/io/rw-lock/win32/ecal_named_rw_lock_impl.h
+++ b/lib/io/rw-lock/win32/ecal_named_rw_lock_impl.h
@@ -105,5 +105,9 @@ namespace eCAL
     void* m_event_handle;
     void* m_shm_handle;
     state* m_lock_state;
+
+    // per lock attributes
+    bool m_holds_write_lock;
+    bool m_holds_read_lock;
   };
 }


### PR DESCRIPTION
and only lock holding participant can release its own lock now. Before this pull request a lock could be aquired by a process and then be released by any other process.